### PR TITLE
Update k3s-01-setup.md

### DIFF
--- a/content/blog/k3s/k3s-01-setup.md
+++ b/content/blog/k3s/k3s-01-setup.md
@@ -299,7 +299,7 @@ RUN cd /usr/local/bin && \
    tar xfvz kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
    rm kustomize_${KUSTOMIZE_VERSION}_linux_amd64.tar.gz && \
  echo "### Flux: " && \
-   curl -s https://toolkit.fluxcd.io/install.sh | bash && \
+   curl -sL https://toolkit.fluxcd.io/install.sh | bash && \
  echo "### cdk8s / pyenv" && \
    apk add libffi-dev openssl-dev bzip2-dev zlib-dev readline-dev \
       sqlite-dev build-base python3 py3-pip yarn npm && \


### PR DESCRIPTION
follows a redirect (`curl -L`), otherwise piping to bash is broken

```
ubuntu@amd-20211127-1715:~/git/flux-infra/k3s.example.com$  curl -s https://toolkit.fluxcd.io/install.sh
Redirecting to https://fluxcd.io/install.sh
ubuntu@amd-20211127-1715:~/git/flux-infra/k3s.example.com$  curl -s https://toolkit.fluxcd.io/install.sh | bash
bash: line 1: Redirecting: command not found

```